### PR TITLE
docs(adoption): canonical first jobs + 30-minute quickstart

### DIFF
--- a/.docs/tasks/v0.5/T4_canonical_first_agent_jobs.md
+++ b/.docs/tasks/v0.5/T4_canonical_first_agent_jobs.md
@@ -2,7 +2,7 @@
 
 depends_on: [T1]
 track: B
-status: pending
+status: completed
 
 ## Objective
 

--- a/.docs/tasks/v0.5/T5_quickstart_30min.md
+++ b/.docs/tasks/v0.5/T5_quickstart_30min.md
@@ -2,7 +2,7 @@
 
 depends_on: [T4]
 track: B
-status: pending
+status: completed
 
 ## Objective
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,16 @@ Enablement precedence:
 - If `PLUGIN_AGENTS_ENABLED` is set, it overrides CP/plugin setting state.
 - If `PLUGIN_AGENTS_ENABLED` is not set, CP/plugin setting `enabled` controls runtime on/off.
 
+## Quickstart and Canonical Jobs
+
+- 30-minute first-success path: [docs/quickstart-30min.md](docs/quickstart-30min.md)
+- Canonical first agent jobs: [docs/canonical-first-agent-jobs.md](docs/canonical-first-agent-jobs.md)
+
 ## Support
 
 - Docs: https://marcusscheller.com/docs/agents/
+- Quickstart (repo): [docs/quickstart-30min.md](docs/quickstart-30min.md)
+- Canonical jobs (repo): [docs/canonical-first-agent-jobs.md](docs/canonical-first-agent-jobs.md)
 - Issues: https://github.com/klick/agents/issues
 - Source: https://github.com/klick/agents
 

--- a/docs/canonical-first-agent-jobs.md
+++ b/docs/canonical-first-agent-jobs.md
@@ -1,0 +1,138 @@
+# Canonical First Agent Jobs
+
+These are the three recommended first jobs for new integrations.
+
+## Prerequisites
+
+- Agents plugin enabled.
+- API token/credential configured.
+- Base URL set (for example `https://example.test/agents/v1`).
+
+## Job 1: Catalog + Content Sync Loop
+
+Purpose: keep a downstream index current with products and content entries.
+
+Required scopes:
+
+- `auth:read`
+- `products:read`
+- `entries:read`
+- `changes:read`
+- `consumers:write`
+
+Flow:
+
+1. Verify token and scopes.
+2. Pull an initial products snapshot.
+3. Pull an initial entries snapshot.
+4. Continue with the changes feed.
+5. Persist your cursor/checkpoint.
+
+Example calls:
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/auth/whoami"
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/products?status=live&limit=100"
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/entries?status=live&limit=100"
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/changes?types=products,entries&limit=100"
+```
+
+Checkpoint payload example:
+
+```json
+{
+  "integrationKey": "catalog-sync",
+  "resourceType": "changes",
+  "cursor": "opaque-cursor-token",
+  "updatedSince": "2026-03-03T00:00:00Z",
+  "checkpointAt": "2026-03-03T12:00:00Z",
+  "metadata": {"worker": "sync-a", "version": "1"}
+}
+```
+
+## Job 2: Support Context Lookup
+
+Purpose: retrieve order and content context for support workflows.
+
+Required scopes:
+
+- `auth:read`
+- `orders:read`
+- `entries:read`
+- `entries:read_all_statuses` (optional, if drafts/non-live are required)
+
+Flow:
+
+1. Pull recent orders.
+2. Resolve one order by `number` or `id`.
+3. Pull support content entries by section/search.
+
+Example calls:
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/orders?status=all&lastDays=14&limit=20"
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/orders/show?number=A1B2C3D4"
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/entries?section=support&status=live&limit=20"
+```
+
+## Job 3: Governed Return/Refund Approval Run
+
+Purpose: execute a high-risk action only after policy and approval checks.
+
+This flow requires `PLUGIN_AGENTS_REFUND_APPROVALS_EXPERIMENTAL=true`.
+
+Required scopes (requester):
+
+- `control:approvals:request`
+- `control:approvals:read`
+
+Required scopes (approver/executor):
+
+- `control:approvals:decide`
+- `control:actions:execute`
+- `control:executions:read`
+
+Flow:
+
+1. Request approval for the action.
+2. Review pending approvals.
+3. Decide approval.
+4. Execute action against approved request.
+5. Audit result in execution ledger.
+
+Approval request payload example:
+
+```json
+{
+  "actionType": "return.request",
+  "actionRef": "RET-100045",
+  "reason": "Customer return requested",
+  "metadata": {
+    "source": "agent-runtime",
+    "agentId": "returns-orchestrator",
+    "traceId": "trace-100045"
+  },
+  "payload": {
+    "orderNumber": "A1B2C3D4",
+    "amount": 49.9,
+    "currency": "GBP",
+    "lineItems": [{"sku": "SKU-123", "qty": 1}]
+  }
+}
+```
+
+Execute payload example:
+
+```json
+{
+  "actionType": "return.request",
+  "actionRef": "RET-100045",
+  "approvalId": 123,
+  "idempotencyKey": "return-ret-100045-v1",
+  "payload": {
+    "orderNumber": "A1B2C3D4",
+    "amount": 49.9,
+    "currency": "GBP"
+  }
+}
+```

--- a/docs/quickstart-30min.md
+++ b/docs/quickstart-30min.md
@@ -1,0 +1,63 @@
+# 30-Minute Quickstart (First Successful Action)
+
+Goal: complete your first successful machine action in under 30 minutes.
+
+## 1. Set base variables
+
+```bash
+export SITE_URL="https://example.test"
+export BASE_URL="$SITE_URL/agents/v1"
+export AGENTS_TOKEN="replace-with-token"
+```
+
+## 2. Configure runtime token + scopes
+
+Set at minimum:
+
+- `PLUGIN_AGENTS_ENABLED=true`
+- `PLUGIN_AGENTS_REQUIRE_TOKEN=true`
+- `PLUGIN_AGENTS_API_TOKEN=<token>`
+- `PLUGIN_AGENTS_TOKEN_SCOPES=health:read,auth:read,products:read`
+
+## 3. Verify runtime health
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/health"
+```
+
+Expected: JSON with `status` and readiness checks.
+
+## 4. Verify caller identity and scopes
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/auth/whoami"
+```
+
+Expected: JSON with `principal` and `authorization.grantedScopes`.
+
+## 5. Run first successful business action
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/products?status=live&limit=10"
+```
+
+Expected: JSON with `data` array.
+
+## 6. Confirm deterministic validation behavior
+
+```bash
+curl -sS -H "Authorization: Bearer $AGENTS_TOKEN" "$BASE_URL/products?limit=abc"
+```
+
+Expected: HTTP `400` and error payload with:
+
+- `error: INVALID_REQUEST`
+- `status: 400`
+- `details` with query validation reason
+
+## Troubleshooting
+
+- `401 UNAUTHORIZED`: token missing/invalid; re-check `Authorization` header and configured token.
+- `403 FORBIDDEN`: token valid but scope missing; add required scope and retry.
+- `503 SERVICE_DISABLED`: set `PLUGIN_AGENTS_ENABLED=true`.
+- `400 INVALID_REQUEST`: fix query parameter format/range as indicated in `details`.


### PR DESCRIPTION
Summary:
- add three canonical first agent jobs with end-to-end API flows
- include required scopes and sample payloads for each job
- add a copy/paste quickstart path targeting first successful action in under 30 minutes
- link quickstart and canonical jobs from README support/discovery sections
- mark roadmap tasks T4 and T5 completed

Validation:
- scripts/qa/release-gate.sh
